### PR TITLE
Add input loader and CLI option for paint scraper

### DIFF
--- a/src/input_loader.py
+++ b/src/input_loader.py
@@ -1,0 +1,94 @@
+"""Load paint identifiers from a CSV or JSON file.
+
+The module exposes :func:`load_ids` which reads a file containing paint
+identifiers and returns them as a list. The loader accepts either CSV or
+JSON input. JSON files may contain JavaScript style ``//`` comments which
+are stripped before parsing.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+import logging
+import re
+from pathlib import Path
+from typing import List
+
+logger = logging.getLogger(__name__)
+
+_ID_RE = re.compile(r"^\d+$")
+
+
+def _is_valid(value: str) -> bool:
+    """Return ``True`` if *value* looks like a valid paint identifier.
+
+    Invalid identifiers are logged and skipped by :func:`load_ids`.
+    """
+
+    if _ID_RE.fullmatch(value):
+        return True
+    logger.warning("Invalid paint id '%s' skipped", value)
+    return False
+
+
+def _strip_json_comments(text: str) -> str:
+    """Remove ``//`` comments from *text* so it can be parsed as JSON."""
+
+    return re.sub(r"//.*", "", text)
+
+
+def _extract_from_obj(obj: object) -> List[str]:
+    """Recursively extract identifier strings from *obj*."""
+
+    ids: List[str] = []
+    if isinstance(obj, dict):
+        for value in obj.values():
+            ids.extend(_extract_from_obj(value))
+    elif isinstance(obj, list):
+        for item in obj:
+            ids.extend(_extract_from_obj(item))
+    elif isinstance(obj, str) and _is_valid(obj):
+        ids.append(obj)
+    return ids
+
+
+def _load_json(path: Path) -> List[str]:
+    text = path.read_text(encoding="utf-8")
+    data = json.loads(_strip_json_comments(text))
+    return _extract_from_obj(data)
+
+
+def _load_csv(path: Path) -> List[str]:
+    ids: List[str] = []
+    with path.open(newline="", encoding="utf-8") as fh:
+        reader = csv.reader(fh)
+        for row in reader:
+            for cell in row:
+                cell = cell.strip()
+                if _is_valid(cell):
+                    ids.append(cell)
+    return ids
+
+
+def load_ids(path: str | Path) -> List[str]:
+    """Load paint identifiers from *path*.
+
+    Parameters
+    ----------
+    path:
+        Path to a JSON or CSV file containing paint identifiers.
+
+    Returns
+    -------
+    list[str]
+        List of validated paint identifiers.
+    """
+
+    p = Path(path)
+    suffix = p.suffix.lower()
+    if suffix == ".json":
+        return _load_json(p)
+    if suffix == ".csv":
+        return _load_csv(p)
+    raise ValueError(f"Unsupported file format: {p.suffix}")

--- a/src/scraper.py
+++ b/src/scraper.py
@@ -1,9 +1,13 @@
+import argparse
 import logging
 import time
+from pathlib import Path
 from typing import Dict, Optional
 
 import requests
 from bs4 import BeautifulSoup
+
+from src import input_loader
 
 logger = logging.getLogger(__name__)
 
@@ -83,3 +87,26 @@ def fetch_paint_price(
         return {"product_id": product_id, "name": name, "price": price}
 
     return None
+
+
+def main() -> None:
+    """Command-line interface for fetching paint prices."""
+
+    parser = argparse.ArgumentParser(description="Fetch paint product prices")
+    parser.add_argument(
+        "--input-file",
+        type=Path,
+        default=Path(__file__).with_name("SKUs.json"),
+        help="CSV or JSON file containing paint IDs.",
+    )
+    args = parser.parse_args()
+
+    ids = input_loader.load_ids(args.input_file)
+
+    sess = requests.Session()
+    for pid in ids:
+        fetch_paint_price(pid, session=sess)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_input_loader.py
+++ b/tests/test_input_loader.py
@@ -1,0 +1,30 @@
+import sys
+import textwrap
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+from input_loader import load_ids
+
+
+def test_load_ids_from_json(tmp_path: Path) -> None:
+    content = textwrap.dedent(
+        """
+        {
+          // comment for group
+          "group": {
+            "a": "123",
+            "b": ["456", "abc"]
+          }
+        }
+        """
+    )
+    path = tmp_path / "ids.json"
+    path.write_text(content)
+    assert load_ids(path) == ["123", "456"]
+
+
+def test_load_ids_from_csv(tmp_path: Path) -> None:
+    csv_content = "123,abc\n456\n"
+    path = tmp_path / "ids.csv"
+    path.write_text(csv_content)
+    assert load_ids(path) == ["123", "456"]


### PR DESCRIPTION
## Summary
- add `input_loader` module to read paint IDs from CSV or JSON (with `//` comments)
- expose `--input-file` option in scraper to choose data source and process IDs
- cover JSON and CSV loaders with unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688d9e0c13188324b61840e94af5a589