### PR TITLE
Add command line interface for price sheet generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,24 @@ This project will generate a printable price sheet for paint products.
 
 ## Usage
 
-Add your implementation to the `src/` directory and tests to `tests/`.
+Generate a PDF price sheet from a list of paint identifiers using the
+command line interface:
+
+```bash
+python -m src.cli --input-file SKUs.json --output-file output/price_sheet.pdf
+```
+
+The CLI accepts a CSV or JSON file of identifiers and produces a themed
+PDF.  Additional options allow customising the colours and fonts:
+
+```
+--header-text TEXT        Text to display in the document header
+--header-color COLOR      Header background colour
+--text-color COLOR        Default text colour
+--background-color COLOR  Page background colour
+--font-family NAME        Font family to use
+```
+
 Run tests with:
 
 ```bash

--- a/src/cli.py
+++ b/src/cli.py
@@ -1,0 +1,129 @@
+"""Command line interface for PaintPriceSheetGenerator.
+
+This module provides a small command line utility that wires together the
+input loader, web scraper and PDF generator to produce a printable price
+sheet.  It accepts options for the input file, output file and various
+theming choices that control the look of the resulting PDF.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from pathlib import Path
+from typing import Iterable, Dict, Any, List
+
+from src import input_loader, scraper, generator
+
+logger = logging.getLogger(__name__)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Create the :mod:`argparse` parser for the CLI."""
+
+    parser = argparse.ArgumentParser(
+        description="Generate a printable price sheet for paint products"
+    )
+    parser.add_argument(
+        "--input-file",
+        type=Path,
+        default=Path(__file__).with_name("SKUs.json"),
+        help="CSV or JSON file containing paint IDs (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--output-file",
+        type=Path,
+        default=Path("output/price_sheet.pdf"),
+        help="Destination for generated PDF (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--header-text",
+        default=generator.Theme.header_text,
+        help="Text to display in the document header",
+    )
+    parser.add_argument(
+        "--header-color",
+        default=generator.Theme.header_color,
+        help="Colour of the header background",
+    )
+    parser.add_argument(
+        "--text-color",
+        default=generator.Theme.text_color,
+        help="Default text colour",
+    )
+    parser.add_argument(
+        "--background-color",
+        default=generator.Theme.background_color,
+        help="Page background colour",
+    )
+    parser.add_argument(
+        "--font-family",
+        default=generator.Theme.font_family,
+        help="Font family to use",
+    )
+    return parser
+
+
+def _scrape_prices(ids: Iterable[str]) -> List[Dict[str, Any]]:
+    """Fetch product information for all *ids*.
+
+    Parameters
+    ----------
+    ids:
+        Iterable of product identifiers.
+
+    Returns
+    -------
+    list[dict]
+        List of price information dictionaries as returned by
+        :func:`scraper.fetch_paint_price`.  Entries that fail to
+        download are skipped.
+    """
+
+    items: List[Dict[str, Any]] = []
+    session = scraper.requests.Session()  # type: ignore[attr-defined]
+    for pid in ids:
+        info = scraper.fetch_paint_price(pid, session=session)
+        if info:
+            items.append(info)
+    return items
+
+
+def main(argv: Iterable[str] | None = None) -> Path:
+    """Run the command line interface.
+
+    Parameters
+    ----------
+    argv:
+        Optional iterable of strings representing command line arguments.
+
+    Returns
+    -------
+    :class:`pathlib.Path`
+        The path to the generated PDF file.
+    """
+
+    parser = _build_parser()
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    logging.basicConfig(level=logging.INFO)
+    logger.info("Loading product identifiers from %s", args.input_file)
+    ids = input_loader.load_ids(args.input_file)
+
+    logger.info("Scraping prices for %d products", len(ids))
+    items = _scrape_prices(ids)
+
+    theme = generator.Theme(
+        header_text=args.header_text,
+        header_color=args.header_color,
+        text_color=args.text_color,
+        background_color=args.background_color,
+        font_family=args.font_family,
+    )
+
+    logger.info("Generating price sheet: %s", args.output_file)
+    return generator.generate_price_sheet(items, theme=theme, output_file=args.output_file)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,66 @@
+import pathlib
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from src import cli
+
+
+class DummySession:
+    pass
+
+
+def test_cli_runs_pipeline(tmp_path, monkeypatch):
+    # prepare input file
+    input_file = tmp_path / "ids.csv"
+    input_file.write_text("111\n222\n")
+
+    items = [
+        {"product_id": "111", "name": "Red", "price": "$1"},
+        {"product_id": "222", "name": "Blue", "price": "$2"},
+    ]
+
+    def fake_fetch(pid, session=None):
+        return next((i for i in items if i["product_id"] == pid), None)
+
+    monkeypatch.setattr(cli.scraper, "fetch_paint_price", fake_fetch)
+    monkeypatch.setattr(cli.scraper.requests, "Session", lambda: DummySession())
+
+    captured = {}
+
+    def fake_generate(data, theme, output_file):
+        captured["items"] = list(data)
+        captured["theme"] = theme
+        captured["output_file"] = pathlib.Path(output_file)
+        return captured["output_file"]
+
+    monkeypatch.setattr(cli.generator, "generate_price_sheet", fake_generate)
+
+    output = tmp_path / "out.pdf"
+    cli.main(
+        [
+            "--input-file",
+            str(input_file),
+            "--output-file",
+            str(output),
+            "--header-text",
+            "My Sheet",
+            "--header-color",
+            "#FF0000",
+            "--text-color",
+            "#00FF00",
+            "--background-color",
+            "#0000FF",
+            "--font-family",
+            "Comic Sans",
+        ]
+    )
+
+    assert captured["items"] == items
+    assert captured["output_file"] == output
+    theme = captured["theme"]
+    assert theme.header_text == "My Sheet"
+    assert theme.header_color == "#FF0000"
+    assert theme.text_color == "#00FF00"
+    assert theme.background_color == "#0000FF"
+    assert theme.font_family == "Comic Sans"


### PR DESCRIPTION
## Summary
- implement `src.cli` using argparse to orchestrate input loading, scraping, and PDF generation
- expose theme-related options and I/O paths
- document CLI usage in README
- add CLI unit test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e600275b483248be94240c5037b89