### PR TITLE
Add tests and CI for scraper and generator

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run tests
+        run: pytest

--- a/README.md
+++ b/README.md
@@ -34,11 +34,17 @@ PDF.  Additional options allow customising the colours and fonts:
 --font-family NAME        Font family to use
 ```
 
-Run tests with:
+## Testing
+
+The project uses `pytest` for its test suite. After installing the
+dependencies, run the tests with:
 
 ```bash
 pytest
 ```
+
+Continuous integration is configured via GitHub Actions to execute the
+tests on each commit.
 
 Data files can be stored in the `data/` directory.
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+addopts = -ra
+testpaths = tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests
 beautifulsoup4
 weasyprint
+pytest

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -2,23 +2,36 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
-from generator import Theme, generate_price_sheet  # type: ignore
+import generator  # type: ignore
 
 
-def test_generate_price_sheet(tmp_path: Path) -> None:
+def test_generate_price_sheet(tmp_path: Path, monkeypatch) -> None:
     data = [
         {"product_id": "1", "name": "Red Paint", "price": "$10"},
         {"product_id": "2", "name": "Blue Paint", "price": "$12"},
     ]
-    theme = Theme(
+    theme = generator.Theme(
         header_text="Test Sheet",
         header_color="#FF0000",
         text_color="#000000",
         background_color="#FFFFFF",
         font_family="Arial",
     )
+    captured = {}
+
+    class DummyHTML:
+        def __init__(self, string: str):
+            captured["html"] = string
+
+        def write_pdf(self, filename: str) -> None:
+            Path(filename).write_bytes(b"%PDF-1.4\n%%EOF")
+
+    monkeypatch.setattr(generator, "HTML", DummyHTML)
+
     output = tmp_path / "sheet.pdf"
-    generate_price_sheet(data, theme, output)
+    generator.generate_price_sheet(data, theme, output)
     assert output.exists()
-    assert output.stat().st_size > 0
     assert output.read_bytes().startswith(b"%PDF")
+    html = captured["html"]
+    assert "Test Sheet" in html
+    assert "#FF0000" in html

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -13,6 +13,20 @@ class DummyResponse:
             raise requests.HTTPError()
 
 
+def test_fetch_parses_price(monkeypatch):
+    """HTML responses are parsed for name and price information."""
+
+    html = '<h1>Fancy Paint</h1><div class="price">$9.99</div>'
+    session = requests.Session()
+    # Return a dummy response instead of performing a real HTTP request
+    monkeypatch.setattr(
+        session, "get", lambda url, headers, timeout: DummyResponse(html)
+    )
+
+    info = scraper.fetch_paint_price("sku123", session=session)
+    assert info == {"product_id": "sku123", "name": "Fancy Paint", "price": "$9.99"}
+
+
 def test_fetch_uses_cache(tmp_path, monkeypatch):
     html = '<h1>Paint</h1><div class="price">$5</div>'
     session = requests.Session()


### PR DESCRIPTION
## Summary
- add test for scraper price parsing with mocked HTTP responses
- ensure generator uses theme values and produces PDF in tests
- configure pytest and add GitHub Actions workflow for CI

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e70f8b7488324a3950e9077ff612a